### PR TITLE
Add TsLint support to affiance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Affiance Changelog
 
+## 1.6.0
+* Add TsLint pre-commit hook
+
+## 1.5.1
+* Fix ad hoc hook creation
+
+## 1.5.0
+* Add ignoreMessagePattern setting on hooks to allow messages that follow a pattern to be ignored.
+  Useful for working around missing features in linters.
+
+## 1.4.0
+* Add NspCheck hook 
+
+## 1.3.5
+* Work around empty stylint results when linting large files
+
+## 1.3.4
+* Fix problemOnUnmodifiedLine setting
+
 ## 1.3.3
 * Fix link in starter config file
 

--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ limitation.
 * [`*`MergeConflicts](lib/hook/pre-commit/MergeConflicts.js)
 * [MochaOnly](lib/hook/pre-commit/MochaOnly.js)
 * [StylusLint](lib/hook/pre-commit/StylusLint.js)
+* [TsLint](lib/hook/pre-commit/TsLint.js)
 
 ### PrePush
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -121,6 +121,17 @@ PreCommit:
     globalInstallCommand: 'npm install -g stylint stylint-json-reporter'
     include: '**/*.styl'
 
+  TsLint:
+    enabled: false
+    description: 'Analyze with TsLint'
+    requiredExecutable: './node_modules/.bin/tslint'
+    globalRequiredExecutable: 'tslint'
+    flags: ['--format', 'prose']
+    installCommand: 'npm install tslint'
+    globalInstallCommand: 'npm install -g tslint'
+    include: '**/*.ts'
+    exclude: '*.yml'
+
 # Hooks that run after HEAD changes or a file is explicitly checked out.
 PostCheckout:
   ALL:

--- a/lib/hook/pre-commit/TsLint.js
+++ b/lib/hook/pre-commit/TsLint.js
@@ -1,0 +1,78 @@
+'use strict';
+const PreCommitBase = require('./Base');
+
+/**
+ * @class TsLint
+ * @extends PreCommitBase
+ * @classdesc Run tslint on changed files
+ */
+class TsLint extends PreCommitBase {
+
+  /**
+   * Run `tslint` against files that apply.
+   * Uses spawnPromiseOnApplicableFiles to parallelize
+   *
+   * @returns {Promise}
+   * @resolves {HookMessage[]} An array of hook messages produced by the hook
+   * @rejects {Error} An Error thrown or emitted while running the hook
+   */
+  run() {
+    return new Promise((resolve, reject) => {
+      this.spawnPromiseOnApplicableFiles().then((result) => {
+        let output = result.stdout.trim();
+        if (result.status === 0 && !output) { return resolve('pass'); }
+
+        resolve(this.extractMessages(
+          this.parseTsLintOutput(output),
+          TsLint.MESSAGE_REGEX,
+          TsLint.MESSAGE_CAPTURE_MAP,
+          TsLint.MESSAGE_TYPE_CATEGORIZER
+        ));
+      }, reject);
+    });
+  }
+
+  // Parses the output stream of TsLint to produce an array of
+  // output messages. Ensures we only send valid lines to the
+  // standard `extractMessages` function.
+  // For example, TsLint will print a warning if some rules aren't well defined like:
+  // `Warning: The 'deprecation' rule requires type information.`
+  // which is useful information, but not for our purposes.
+  parseTsLintOutput(output) {
+    let outputLines = output.split('\n');
+    return outputLines.filter((outputLine) => {
+      return /ERROR|WARNING/.test(outputLine);
+    });
+  }
+
+  static MESSAGE_TYPE_CATEGORIZER(capturedType) {
+    return capturedType.toLowerCase();
+  }
+}
+
+/**
+ * Regex to capture various parts of TsLint "prose" output.
+ * The output lines look like this:
+ * ERROR: relative/path.ts:L:C - Rule name
+ *
+ * @type {RegExp}
+ */
+TsLint.MESSAGE_REGEX = new RegExp(
+  '^(ERROR|WARNING):\\s+' + // 1: Type
+  '([^:]+):' + // 2: File name
+  '(\\d+):.*$' // 3: Line number
+);
+
+/**
+ * Maps the types of captured data to the index in the
+ * matches array produced when executing `MESSAGE_REGEX`
+ *
+ * @type {{file: number, line: number, type: number}}
+ */
+TsLint.MESSAGE_CAPTURE_MAP = {
+  'type': 1,
+  'file': 2,
+  'line': 3
+};
+
+module.exports = TsLint;

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "affiance": "file:./",
     "chai": "^3.5.0",
-    "eslint": "^3.19.0",
+    "eslint": "^4.18.2",
     "mocha": "^3.1.2",
     "sinon": "^1.17.6",
     "sinon-chai": "^2.8.0"

--- a/test/unit/lib/hook/pre-commit/TsLint.test.js
+++ b/test/unit/lib/hook/pre-commit/TsLint.test.js
@@ -1,0 +1,68 @@
+'use strict';
+const testHelper = require('../../../../test_helper');
+const expect = testHelper.expect;
+const sinon = testHelper.sinon;
+const TsLint = testHelper.requireSourceModule(module);
+const Config = testHelper.requireSourceModule(module, 'lib/config');
+const HookContextPreCommit = testHelper.requireSourceModule(module, 'lib/hook-context/pre-commit');
+
+describe('TsLint', function() {
+  beforeEach('setup hook context', function() {
+    this.sandbox = sinon.sandbox.create();
+    this.config = new Config({});
+    this.context = new HookContextPreCommit(this.config, [], {});
+    this.hook = new TsLint(this.config, this.context);
+
+    this.result = {
+      status: 0,
+      stderr: '',
+      stdout: ''
+    };
+    this.sandbox.stub(this.hook, 'spawnPromiseOnApplicableFiles').returns(Promise.resolve(this.result));
+  });
+
+  afterEach('restore sandbox', function() {
+    this.sandbox.restore();
+  });
+
+  it('passes when there are no messages output', function() {
+    this.result.stdout = '';
+
+    return this.hook.run().then((hookResults) => {
+      expect(hookResults).to.equal('pass');
+    });
+  });
+
+  it('warns when there are messages output', function() {
+    this.result.stdout = [
+      "Warning: The 'deprecation' rule requires type information.",
+      "WARNING: relative/path.ts:15:35 - Type declaration of 'any' loses type-safety.",
+      ''
+    ].join('\n');
+
+    return this.hook.run().then((hookResults) => {
+      expect(hookResults).to.have.length(1);
+      expect(hookResults[0]).to.have.property('content', 'WARNING: relative/path.ts:15:35 - Type declaration of \'any\' loses type-safety.');
+      expect(hookResults[0]).to.have.property('file', 'relative/path.ts');
+      expect(hookResults[0]).to.have.property('line', 15);
+      expect(hookResults[0]).to.have.property('type', 'warning');
+    });
+  });
+
+  it('fails when there is an error in the output', function() {
+    this.result.status = 1;
+    this.result.stdout = [
+      "Warning: The 'deprecation' rule requires type information.",
+      'ERROR: relative/path.ts:16:12 - Missing semicolon',
+      ''
+    ].join('\n');
+
+    return this.hook.run().then((hookResults) => {
+      expect(hookResults).to.have.length(1);
+      expect(hookResults[0]).to.have.property('content', 'ERROR: relative/path.ts:16:12 - Missing semicolon');
+      expect(hookResults[0]).to.have.property('file', 'relative/path.ts');
+      expect(hookResults[0]).to.have.property('line', 16);
+      expect(hookResults[0]).to.have.property('type', 'error');
+    });
+  });
+});


### PR DESCRIPTION
This adds support for `tslint` to affiance. This includes the default
configration and a pre-commit hook class to handle tslint's output.

* Add `TsLint` class to `hook/pre-commit` directory
* Add unit tests for `TsLint` to ensure that pass, fail, and warn work
  as expected with the `prose` output.
* Add a `TsLint` section to the default.yml file that applies to `.ts`
  files by default and uses the `prose` format