### PR TITLE
Use npm/JavaScript lingo

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ requiring `sudo` privileges. Using a Node version manager like
 [`nvm`](https://github.com/creationix/nvm/blob/master/README.markdown) can help
 here.
 
-Once you have an environment that allows you to install gems without `sudo`,
+Once you have an environment that allows you to install packages without `sudo`,
 you can run the following command to make affiance available globally:
 
 ### Global installation


### PR DESCRIPTION
In the Ruby ecosystem (where [overcommit](https://github.com/brigade/overcommit), its inspiration, thrives) they are called _gems_. 
In the npm/JavaScript ecosystem, they are called _packages_, methinks.