### PR TITLE
Add spectral pre-commit hook support to affiance

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ limitation.
 * [EsLint](lib/hook/pre-commit/EsLint.js)
 * [`*`MergeConflicts](lib/hook/pre-commit/MergeConflicts.js)
 * [MochaOnly](lib/hook/pre-commit/MochaOnly.js)
+* [Spectral](lib/hook/pre-commit/Spectral.js)
 * [StylusLint](lib/hook/pre-commit/StylusLint.js)
 * [TsLint](lib/hook/pre-commit/TsLint.js)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -109,6 +109,19 @@ PreCommit:
     flags: ['-EIHn', '(it|describe)\.only']
     include: 'test/**/*.js'
 
+  Spectral:
+    enabled: false
+    description: 'Analyze with Spectral'
+    requiredExecutable: './node_modules/.bin/spectral'
+    globalRequiredExecutable: 'spectral'
+    flags: ['--quiet', '--ignore-unknown-format', '--format', 'text']
+    installCommand: 'npm install @stoplight/spectral'
+    globalInstallCommand: 'npm install -g @stoplight/spectral'
+    include:
+      - '**/*.js'
+      - '**/*.yml'
+      - '**/*.yaml'
+
   StylusLint:
     enabled: false
     description: "Analyze with stylus linter"

--- a/config/default.yml
+++ b/config/default.yml
@@ -114,7 +114,7 @@ PreCommit:
     description: 'Analyze with Spectral'
     requiredExecutable: './node_modules/.bin/spectral'
     globalRequiredExecutable: 'spectral'
-    flags: ['--quiet', '--ignore-unknown-format', '--format', 'text']
+    flags: ['lint', '--quiet', '--ignore-unknown-format', '--format', 'text']
     installCommand: 'npm install @stoplight/spectral'
     globalInstallCommand: 'npm install -g @stoplight/spectral'
     include:

--- a/config/default.yml
+++ b/config/default.yml
@@ -118,9 +118,10 @@ PreCommit:
     installCommand: 'npm install @stoplight/spectral'
     globalInstallCommand: 'npm install -g @stoplight/spectral'
     include:
-      - '**/*.js'
+      - '**/*.json'
       - '**/*.yml'
       - '**/*.yaml'
+    exclude: 'package.json'
 
   StylusLint:
     enabled: false

--- a/lib/hook/pre-commit/Spectral.js
+++ b/lib/hook/pre-commit/Spectral.js
@@ -1,0 +1,74 @@
+'use strict';
+const PreCommitBase = require('./Base');
+
+/**
+ * @class Spectral
+ * @extends PreCommitBase
+ * @classdesc Run spectral on changed files
+ */
+class Spectral extends PreCommitBase {
+
+  /**
+   * Run `spectral` against files that apply.
+   * Uses spawnPromiseOnApplicableFiles to parallelize
+   *
+   * @returns {Promise}
+   * @resolves {HookMessage[]} An array of hook messages produced by the hook
+   * @rejects {Error} An Error thrown or emitted while running the hook
+   */
+  run() {
+    return new Promise((resolve, reject) => {
+      this.spawnPromiseOnApplicableFiles().then((result) => {
+        let output = result.stdout.trim();
+        if (result.status === 0 && !output) { return resolve('pass'); }
+
+        resolve(this.extractMessages(
+          this.parseSpectralOutput(output),
+          Spectral.MESSAGE_REGEX,
+          Spectral.MESSAGE_CAPTURE_MAP,
+          Spectral.MESSAGE_TYPE_CATEGORIZER
+        ));
+      }, reject);
+    });
+  }
+
+// Parses the output stream of Spectral to produce an array of
+// output messages. Ensures we only send valid lines to the
+// standard `extractMessages` function.
+  parseSpectralOutput(output) {
+    let outputLines = output.split('\n');
+    return outputLines.filter((outputLine) => {
+      return / error | warning /.test(outputLine);
+    });
+  }
+
+  static MESSAGE_TYPE_CATEGORIZER(capturedType) {
+    return capturedType.toLowerCase();
+  }
+}
+
+/**
+ * Regex to capture various parts of Spectral text output.
+ * The output lines look like this:
+ * `path/to/file.js:1:1 error rule-name "Error message"`
+ * @type {RegExp}
+ */
+Spectral.MESSAGE_REGEX = new RegExp(
+  '^((?:\w:)?[^:]+):' + // 1: File name
+  '(\\d+).*?' + // 2: Line number
+  '(error|warning)' // 3: Type
+);
+
+/**
+ * Maps the types of captured data to the index in the
+ * matches array produced when executing `MESSAGE_REGEX`
+ *
+ * @type {{file: number, line: number, type: number}}
+ */
+Spectral.MESSAGE_CAPTURE_MAP = {
+  'file': 1,
+  'line': 2,
+  'type': 3
+};
+
+module.exports = Spectral;

--- a/test/unit/lib/hook/pre-commit/Spectral.test.js
+++ b/test/unit/lib/hook/pre-commit/Spectral.test.js
@@ -1,0 +1,64 @@
+'use strict';
+const testHelper = require('../../../../test_helper');
+const expect = testHelper.expect;
+const sinon = testHelper.sinon;
+const Spectral = testHelper.requireSourceModule(module);
+const Config = testHelper.requireSourceModule(module, 'lib/config');
+const HookContextPreCommit = testHelper.requireSourceModule(module, 'lib/hook-context/pre-commit');
+
+describe('Spectral', function() {
+  beforeEach('setup hook context', function() {
+    this.sandbox = sinon.sandbox.create();
+    this.config = new Config({});
+    this.context = new HookContextPreCommit(this.config, [], {});
+    this.hook = new Spectral(this.config, this.context);
+
+    this.result = {
+      status: 0,
+      stderr: '',
+      stdout: ''
+    };
+    this.sandbox.stub(this.hook, 'spawnPromiseOnApplicableFiles').returns(Promise.resolve(this.result));
+  });
+
+  afterEach('restore sandbox', function() {
+    this.sandbox.restore();
+  });
+
+  it('passes when there are no messages output', function() {
+    this.result.stdout = '';
+
+    return this.hook.run().then((hookResults) => {
+      expect(hookResults).to.equal('pass');
+    });
+  });
+
+  it('warns when there are messages output', function() {
+    this.result.stdout = [
+      '/path/to/file.js:10:2 warning rule-name "This is a warning message"'
+    ].join('\n');
+
+    return this.hook.run().then((hookResults) => {
+      expect(hookResults).to.have.length(1);
+      expect(hookResults[0]).to.have.property('content', '/path/to/file.js:10:2 warning rule-name "This is a warning message"');
+      expect(hookResults[0]).to.have.property('file', '/path/to/file.js');
+      expect(hookResults[0]).to.have.property('line', 10);
+      expect(hookResults[0]).to.have.property('type', 'warning');
+    });
+  });
+
+  it('fails when there is an error in the output', function() {
+    this.result.status = 1;
+    this.result.stdout = [
+      '/path/to/file.js:20:2 error rule-name "This is an error message"'
+    ].join('\n');
+
+    return this.hook.run().then((hookResults) => {
+      expect(hookResults).to.have.length(1);
+      expect(hookResults[0]).to.have.property('content', '/path/to/file.js:20:2 error rule-name "This is an error message"');
+      expect(hookResults[0]).to.have.property('file', '/path/to/file.js');
+      expect(hookResults[0]).to.have.property('line', 20);
+      expect(hookResults[0]).to.have.property('type', 'error');
+    });
+  });
+});


### PR DESCRIPTION
Add a pre-commit hook for [spectral](https://meta.stoplight.io/docs/spectral/README.md) to affiance.

- Add Spectral class to hook/pre-commit directory
- Add unit tests for Spectral to ensure that pass, fail, and warn work
as expected with the text output.
- Add a Spectral section to the default.yml file that applies to .json, .yml and .yaml files by default and uses the text format
- Add Spectral to the `PreCommit` section of the README