### PR TITLE
Add RBAC deprecation specific lint rule

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -109,6 +109,13 @@ PreCommit:
     flags: ['-EIHn', '(it|describe)\.only']
     include: 'test/**/*.js'
 
+  RBACDeprecated:
+    enabled: false
+    description: 'Check for use of deprecated access role methods'
+    quiet: true
+    flags: ['inInterviewer', 'hasAccessByRole']
+    include: '**/*.js/*.coffee'
+
   Spectral:
     enabled: false
     description: 'Analyze with Spectral'


### PR DESCRIPTION
add rule to check for isInterviewer or hasAccessbyRole method uses, which are both being phased out

unsure if  requiredExecutable field is needed