### PR TITLE
Update spectral package since the referenced one has been deprecated

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -115,8 +115,8 @@ PreCommit:
     requiredExecutable: './node_modules/.bin/spectral'
     globalRequiredExecutable: 'spectral'
     flags: ['lint', '--quiet', '--ignore-unknown-format', '--format', 'text']
-    installCommand: 'npm install @stoplight/spectral'
-    globalInstallCommand: 'npm install -g @stoplight/spectral'
+    installCommand: 'npm install @stoplight/spectral-cli'
+    globalInstallCommand: 'npm install -g @stoplight/spectral-cli'
     include:
       - '**/*.json'
       - '**/*.yml'


### PR DESCRIPTION
Updates the package for spectral to [@stoplight/spectral-cli](https://www.npmjs.com/package/@stoplight/spectral-cli) because [@stoplight/spectral](https://www.npmjs.com/package/@stoplight/spectral) has been deprecated. 